### PR TITLE
fix version of reactIntl to one that has a UMD file

### DIFF
--- a/bindings/kepler.gl-jupyter/js/webpack/build-html.js
+++ b/bindings/kepler.gl-jupyter/js/webpack/build-html.js
@@ -20,7 +20,7 @@ const VERSIONS = {
   reactDom:clearCarats(dependencies['react-dom']),
   redux: clearCarats(dependencies.redux),
   reactRedux: clearCarats(dependencies['react-redux']),
-  reactIntl: clearCarats(dependencies['react-intl']),
+  reactIntl: '4.7.6',
   reactCopyToClipboard: clearCarats(dependencies['react-copy-to-clipboard']),
   styledComponents: clearCarats(dependencies['styled-components']),
   keplergl: clearCarats(dependencies['kepler.gl'])


### PR DESCRIPTION
To fix https://www.notion.so/wherobots/Exported-Kepler-Visualizations-Crash-when-Pulling-Out-Menu-c472ef79e4d64faab4f9e7c90a97ef2a?pvs=4